### PR TITLE
Fix test script

### DIFF
--- a/script/run-tester
+++ b/script/run-tester
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Usage: script/test
 # Description: script to run test

--- a/script/run-tester
+++ b/script/run-tester
@@ -15,13 +15,17 @@ docker kill target > /dev/null 2>&1 || true
 docker rm   target > /dev/null 2>&1 || true
 
 # Test Ruby version
-if [[ $(docker run --rm --name target target ruby -v | grep -e "^ruby ${RUBY_VERSION}" --line-buffered) = "" ]]; then
+target_ruby_version=$(docker run --rm --name target target ruby -v | grep -e "^ruby $RUBY_VERSION" --line-buffered)
+
+if [ "$target_ruby_version" == "" ]; then
   echo "Invalid Ruby version. expected: ${RUBY_VERSION}"
   exit 1
 fi
 
 # Test Infrataster version
-if [[ $(docker run --rm --name target target gem list infrataster | grep -e "^infrataster (${INFRATASTER_VERSION})$" --line-buffered) = "" ]]; then
+target_infrataster_version=$(docker run --rm --name target target gem list infrataster | grep -e "^infrataster ($INFRATASTER_VERSION)$" --line-buffered)
+
+if [ "$target_infrataster_version" == "" ]; then
   echo "Invalid Infrataster version. expected: ${INFRATASTER_VERSION}"
   exit 1
 fi

--- a/script/test
+++ b/script/test
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Usage: script/test
 # Description: script to run test


### PR DESCRIPTION
## WHY

from #7 

Test script has some grammatical errors (in wercker).

https://app.wercker.com/#buildstep/54d9d643739668c1470761c1

``` shell
$ script/run-tester
script/run-tester: 18: script/run-tester: [[: not found
script/run-tester: 24: script/run-tester: [[: not found
```

(but somehow CI passed successfully...)
## WHAT
- Fix test script to use `[ ... ]` notation, instead of `[[ ... ]]` notation.
- Change shebang: `#!/bin/sh` -> `#!/bin/bash`
