### PR TITLE
Update infrataster to v0.2.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
     diff-lcs (1.2.5)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
-    infrataster (0.2.2)
+    infrataster (0.2.6)
       capybara
       faraday
       net-ssh
@@ -19,16 +19,16 @@ GEM
       poltergeist
       rspec (>= 2.0, < 4.0)
       thor
-    mime-types (2.4.3)
+    mime-types (2.5)
     mini_portile (0.6.2)
-    multi_json (1.10.1)
+    multi_json (1.11.0)
     multipart-post (2.0.0)
     net-ssh (2.9.2)
     net-ssh-gateway (1.2.0)
       net-ssh (>= 2.6.5)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
-    poltergeist (1.5.1)
+    poltergeist (1.6.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
@@ -36,22 +36,23 @@ GEM
     rack (1.6.0)
     rack-test (0.6.3)
       rack (>= 1.0)
-    rspec (3.1.0)
-      rspec-core (~> 3.1.0)
-      rspec-expectations (~> 3.1.0)
-      rspec-mocks (~> 3.1.0)
-    rspec-core (3.1.7)
-      rspec-support (~> 3.1.0)
-    rspec-expectations (3.1.2)
+    rspec (3.2.0)
+      rspec-core (~> 3.2.0)
+      rspec-expectations (~> 3.2.0)
+      rspec-mocks (~> 3.2.0)
+    rspec-core (3.2.3)
+      rspec-support (~> 3.2.0)
+    rspec-expectations (3.2.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.1.0)
-    rspec-mocks (3.1.3)
-      rspec-support (~> 3.1.0)
-    rspec-support (3.1.2)
+      rspec-support (~> 3.2.0)
+    rspec-mocks (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-support (3.2.2)
     thor (0.19.1)
-    websocket-driver (0.5.1)
+    websocket-driver (0.5.4)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.1)
+    websocket-extensions (0.1.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -59,4 +60,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  capybara
   infrataster
+  poltergeist

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Please see [official one's README](https://github.com/ryotarai/infrataster/) for
 
 * `latest`
  * Ruby 2.1.5
- * Infrataster v0.2.2
+ * Infrataster v0.2.6
 
 ## HOW TO USE
 

--- a/script/test
+++ b/script/test
@@ -6,7 +6,7 @@
 
 # this script should be run in project root
 BASE_DIRECTORY=`pwd`
-INFRATASTER_VERSION="0.2.2"
+INFRATASTER_VERSION="0.2.6"
 
 echo "==> Building target..."
 cd ${BASE_DIRECTORY}


### PR DESCRIPTION
## WHY

I'd like to use basic auth on some test and basic auth is supported since infrataster v0.2.3.
## REF

[Support basic auth by winebarrel · Pull Request #54 · ryotarai/infrataster](https://github.com/ryotarai/infrataster/pull/54)
