### PR TITLE
Fix test cleanup step

### DIFF
--- a/script/test
+++ b/script/test
@@ -29,5 +29,5 @@ else
 fi
 
 echo "==> Cleaning up..."
-docker kill target > /dev/null 2>&1 || true
-docker rm   target > /dev/null 2>&1 || true
+docker kill infrataster > /dev/null 2>&1 || true
+docker rm   infrataster > /dev/null 2>&1 || true


### PR DESCRIPTION
## WHAT

We currently does not use the image `target` in the test. We use `infrataster`.
