### PR TITLE
Update to Infrataster v0.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem "infrataster"
+gem "infrataster", "0.3.0"
 gem "capybara"
 gem "poltergeist"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
     diff-lcs (1.2.5)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
-    infrataster (0.2.6)
+    infrataster (0.3.0)
       capybara
       faraday
       net-ssh
@@ -19,9 +19,9 @@ GEM
       poltergeist
       rspec (>= 2.0, < 4.0)
       thor
-    mime-types (2.5)
+    mime-types (2.6.1)
     mini_portile (0.6.2)
-    multi_json (1.11.0)
+    multi_json (1.11.2)
     multipart-post (2.0.0)
     net-ssh (2.9.2)
     net-ssh-gateway (1.2.0)
@@ -33,24 +33,24 @@ GEM
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
       websocket-driver (>= 0.2.0)
-    rack (1.6.0)
+    rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
-    rspec (3.2.0)
-      rspec-core (~> 3.2.0)
-      rspec-expectations (~> 3.2.0)
-      rspec-mocks (~> 3.2.0)
-    rspec-core (3.2.3)
-      rspec-support (~> 3.2.0)
-    rspec-expectations (3.2.1)
+    rspec (3.3.0)
+      rspec-core (~> 3.3.0)
+      rspec-expectations (~> 3.3.0)
+      rspec-mocks (~> 3.3.0)
+    rspec-core (3.3.2)
+      rspec-support (~> 3.3.0)
+    rspec-expectations (3.3.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.2.0)
-    rspec-mocks (3.2.1)
+      rspec-support (~> 3.3.0)
+    rspec-mocks (3.3.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.2.0)
-    rspec-support (3.2.2)
+      rspec-support (~> 3.3.0)
+    rspec-support (3.3.0)
     thor (0.19.1)
-    websocket-driver (0.5.4)
+    websocket-driver (0.6.2)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
     xpath (2.0.0)
@@ -61,5 +61,5 @@ PLATFORMS
 
 DEPENDENCIES
   capybara
-  infrataster
+  infrataster (= 0.3.0)
   poltergeist

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Please see [official one's README](https://github.com/ryotarai/infrataster/) for
 
 * `latest`
  * Ruby 2.1.5
- * Infrataster v0.2.6
+ * Infrataster v0.3.0
 
 ## HOW TO USE
 

--- a/script/test
+++ b/script/test
@@ -6,7 +6,7 @@
 
 # this script should be run in project root
 BASE_DIRECTORY=`pwd`
-INFRATASTER_VERSION="0.2.6"
+INFRATASTER_VERSION="0.3.0"
 
 echo "==> Building target..."
 cd ${BASE_DIRECTORY}


### PR DESCRIPTION
## WHAT

Use Infrataster v0.3.0
## WHY

To remove deprecation warnings below:

```
Deprecation Warnings:

The `:example_group` key in an example group's metadata hash is deprecated. Use the example group's hash directly for the computed keys and `:parent_example_group` to access the parent example group metadata instead. Called from /usr/local/lib/ruby/gems/2.1.0/gems/infrataster-0.2.6/lib/infrataster/contexts.rb:11:in `yield'.
The `:example_group` key in an example group's metadata hash is deprecated. Use the example group's hash directly for the computed keys and `:parent_example_group` to access the parent example group metadata instead. Called from /usr/local/lib/ruby/gems/2.1.0/gems/infrataster-0.2.6/lib/infrataster/contexts.rb:35:in `yield'.
```
## REF
- [infrataster/CHANGELOG.md at master · ryotarai/infrataster](https://github.com/ryotarai/infrataster/blob/master/CHANGELOG.md)
